### PR TITLE
[TFF-170] Use consusd on port 8081 for integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ script:
   - consusd start --port=8081
   - cd consus-client
   - npm run integration-test
+  - consusd stop
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ install:
   - git clone https://github.com/TheFourFifths/consus.git
   - cd consus
   - git checkout dev
-  - npm install
+  - npm install -g
   - cd ../
   - git clone https://github.com/TheFourFifths/consus-client.git
   - cd consus-client
@@ -23,8 +23,7 @@ before_script:
   - sleep 3 # give xvfb some time to start
 
 script:
-  - cd consus
-  - npm start --port=8081
+  - consusd start --port=8081
   - cd consus-client
   - npm run integration-test
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ install:
   - git clone https://github.com/TheFourFifths/consus.git
   - cd consus
   - git checkout dev
+  - npm install
   - npm install -g
   - cd ../
   - git clone https://github.com/TheFourFifths/consus-client.git


### PR DESCRIPTION
### Summary

This PR uses `consusd` to run the server in the background for integration tests. It uses port 8081 so that we can run the functional tests with port 8080 acting as a proxy to port 8081, resulting in our integration tests.

Sister PRs (merge **this** PR last!):
* TheFourFifths/consus/pull/69 (merge first!)
* TheFourFifths/consus-client/pull/90 (merge PR second!)

### Checklist

- [x] Have you added unit and functional tests as appropriate?
- [x] Did you update/add documentation for new methods or changed functionality?
- [x] Have you merged the target branch down into this one?

### How to Review

1. Merge the sister PRs first.
2. View the integration tests on Travis.
3. Verify that the tests execute and pass.

### Links

- [TFF-170](https://msoese.atlassian.net/browse/TFF-170)
- TheFourFifths/consus/pull/69
- TheFourFifths/consus-client/pull/90